### PR TITLE
Remove unnecessary complexity.

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -6,6 +6,6 @@ import (
 	"google.golang.org/api/sheets/v4"
 )
 
-func setupRoutes(r *gin.Engine, gsrv *gmail.Service, ssrv *sheets.Service, historyBuffer *[]uint64, messageSet map[string]bool) {
-	r.POST("/webhook", webhookHandler(gsrv, ssrv, historyBuffer, messageSet))
+func setupRoutes(r *gin.Engine, gsrv *gmail.Service, ssrv *sheets.Service, ch chan<- uint64) {
+  r.POST("/webhook", webhookHandler(gsrv, ssrv, ch))
 }


### PR DESCRIPTION
Basically avoid (concurrency(shared state) -> synchronization -> starvation/deadlock) chain as it is not important here:
- The historybuffer and messageset are useless.
- Nullify gin server's concurrency by putting the data in channel to be read by a single receiver.